### PR TITLE
Use && instead of || when looking for all libraries

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -82,10 +82,10 @@ function build()
 
 end # build()
 
-alllibs = find_library("Cairo", "libcairo", ["libcairo-2", "libcairo"]) || 
-          find_library("Cairo", "libfontconfig", ["libfontconfig-1", "libfontconfig"]) ||
-          find_library("Cairo", "libpango",["libpango-1.0-0", "libpango-1.0"]) ||
-          find_library("Cairo", "libpangocairo", ["libpangocairo-1.0-0", "libpangocairo-1.0"]) ||
+alllibs = find_library("Cairo", "libcairo", ["libcairo-2", "libcairo"]) && 
+          find_library("Cairo", "libfontconfig", ["libfontconfig-1", "libfontconfig"]) &&
+          find_library("Cairo", "libpango",["libpango-1.0-0", "libpango-1.0"]) &&
+          find_library("Cairo", "libpangocairo", ["libpangocairo-1.0-0", "libpangocairo-1.0"]) &&
           find_library("Cairo", "libgobject", ["libgobject-2.0-0", "libgobject-2.0"])
 
 if !alllibs; build(); end


### PR DESCRIPTION
Fixes a typo in recent library search overhaul
