### PR TITLE
Get rid of Dict deprecation warnings

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -2,6 +2,8 @@ using BinDeps
 
 @BinDeps.setup
 
+include("../src/compatibility.jl")
+
 group = library_group("cairo")
 
 deps = [
@@ -50,41 +52,47 @@ end
 
 # System Package Managers
 provides(AptGet,
-    {"libcairo2" => cairo,
-     "libfontconfig1" => fontconfig,
-     "libpango1.0-0" => [pango,pangocairo],
-     "libglib2.0-0" => gobject,
-     "libpng12-0" => libpng,
-     "libpixman-1-0" => pixman,
-     "gettext" => gettext})
+    @Dict(
+        "libcairo2" => cairo,
+        "libfontconfig1" => fontconfig,
+        "libpango1.0-0" => [pango,pangocairo],
+        "libglib2.0-0" => gobject,
+        "libpng12-0" => libpng,
+        "libpixman-1-0" => pixman,
+        "gettext" => gettext
+    ))
 
 # TODO: check whether these are accurate
 provides(Yum,
-    {"cairo" => cairo,
-     "fontconfig" => fontconfig,
-     "pango" => [pango,pangocairo],
-     "glib2" => gobject,
-     "libpng" => libpng,
-     "gettext-libs" => gettext})
+    @Dict(
+        "cairo" => cairo,
+        "fontconfig" => fontconfig,
+        "pango" => [pango,pangocairo],
+        "glib2" => gobject,
+        "libpng" => libpng,
+        "gettext-devel" => gettext
+    ))
 
 const png_version = "1.5.14"
 
 provides(Sources,
-    {URI("http://www.cairographics.org/releases/pixman-0.28.2.tar.gz") => pixman,
-     URI("http://www.cairographics.org/releases/cairo-1.12.16.tar.xz") => cairo,
-     URI("http://download.savannah.gnu.org/releases/freetype/freetype-2.4.11.tar.gz") => freetype,
-     URI("http://www.freedesktop.org/software/fontconfig/release/fontconfig-2.10.2.tar.gz") => fontconfig,
-     URI("http://ftp.gnu.org/pub/gnu/gettext/gettext-0.18.2.tar.gz") => gettext,
-     URI("ftp://ftp.simplesystems.org/pub/libpng/png/src/history/libpng15/libpng-$(png_version).tar.gz") => libpng,
-     URI("ftp://sourceware.org/pub/libffi/libffi-3.0.11.tar.gz") => libffi,
-     URI("http://ftp.gnome.org/pub/gnome/sources/glib/2.34/glib-2.34.3.tar.xz") => gobject,
-     URI("http://ftp.gnome.org/pub/GNOME/sources/pango/1.32/pango-1.32.6.tar.xz") => [pango,pangocairo],
-     URI("http://zlib.net/zlib-1.2.7.tar.gz") => zlib})
+    @Dict(
+        URI("http://www.cairographics.org/releases/pixman-0.28.2.tar.gz") => pixman,
+        URI("http://www.cairographics.org/releases/cairo-1.12.16.tar.xz") => cairo,
+        URI("http://download.savannah.gnu.org/releases/freetype/freetype-2.4.11.tar.gz") => freetype,
+        URI("http://www.freedesktop.org/software/fontconfig/release/fontconfig-2.10.2.tar.gz") => fontconfig,
+        URI("http://ftp.gnu.org/pub/gnu/gettext/gettext-0.18.2.tar.gz") => gettext,
+        URI("ftp://ftp.simplesystems.org/pub/libpng/png/src/history/libpng15/libpng-$(png_version).tar.gz") => libpng,
+        URI("ftp://sourceware.org/pub/libffi/libffi-3.0.11.tar.gz") => libffi,
+        URI("http://ftp.gnome.org/pub/gnome/sources/glib/2.34/glib-2.34.3.tar.xz") => gobject,
+        URI("http://ftp.gnome.org/pub/GNOME/sources/pango/1.32/pango-1.32.6.tar.xz") => [pango,pangocairo],
+        URI("http://zlib.net/zlib-1.2.7.tar.gz") => zlib
+    ))
 
 xx(t...) = (OS_NAME == :Windows ? t[1] : (OS_NAME == :Linux || length(t) == 2) ? t[2] : t[3])
 
 provides(BuildProcess,
-    {
+    @Dict(
         Autotools(libtarget = "pixman/libpixman-1.la", installed_libname = xx("libpixman-1-0.","libpixman-1.","libpixman-1.0.")*BinDeps.shlib_ext) => pixman,
         Autotools(libtarget = xx("objs/.libs/libfreetype.la","libfreetype.la")) => freetype,
         Autotools(libtarget = "src/libfontconfig.la") => fontconfig,
@@ -96,7 +104,7 @@ provides(BuildProcess,
         Autotools(libtarget = "libffi.la") => libffi,
         Autotools(libtarget = "gobject/libgobject-2.0.la") => gobject,
         Autotools(libtarget = "pango/libpango-1.0.la") => [pango,pangocairo]
-    })
+    ))
 
 provides(BuildProcess,Autotools(libtarget = "libpng15.la"),libpng,os = :Unix)
 
@@ -133,6 +141,7 @@ provides(BuildProcess,
         end
     end),libpng, os = :Windows)
 
-@BinDeps.install [:gobject => :_jl_libgobject, :cairo => :_jl_libcairo, 
-                  :pango => :_jl_libpango, :pangocairo => :_jl_libpangocairo]
-
+@BinDeps.install Dict([(:gobject, :_jl_libgobject),
+                       (:cairo, :_jl_libcairo),
+                       (:pango, :_jl_libpango),
+                       (:pangocairo, :_jl_libpangocairo)])

--- a/src/Cairo.jl
+++ b/src/Cairo.jl
@@ -1,5 +1,7 @@
 module Cairo
 
+include("compatibility.jl")
+
 include("../deps/deps.jl")
 
 using Color
@@ -22,8 +24,8 @@ export
     # surface and context management
     finish, destroy, status, get_source,
     creategc, getgc, save, restore, show_page, width, height,
-    
-    # pattern 
+
+    # pattern
     pattern_create_radial, pattern_create_linear,
     pattern_add_color_stop_rgb, pattern_add_color_stop_rgba,
     pattern_set_filter, pattern_set_extend,
@@ -48,7 +50,7 @@ export
     fill, fill_preserve, new_path, new_sub_path, close_path, paint, stroke,
     stroke_preserve, stroke_transformed, stroke_transformed_preserve,
     move_to, line_to, rel_line_to, rel_move_to,
-    rectangle, circle, arc, arc_negative, 
+    rectangle, circle, arc, arc_negative,
     curve_to, rel_curve_to,
     path_extents,
 
@@ -449,7 +451,7 @@ for (NAME, FUNCTION) in {(:arc, :cairo_arc),
     @eval begin
         $NAME(ctx::CairoContext, xc::Real, yc::Real, radius::Real, angle1::Real, angle2::Real) =
             ccall(($(Expr(:quote,FUNCTION)),_jl_libcairo),
-                  Void, (Ptr{Void},Float64,Float64,Float64,Float64,Float64), 
+                  Void, (Ptr{Void},Float64,Float64,Float64,Float64,Float64),
                   ctx.ptr, xc, yc, radius, angle1, angle2)
     end
 end
@@ -636,7 +638,7 @@ set_antialias(ctx::CairoContext, a) =
     ccall((:cairo_set_antialias,_jl_libcairo), Void,
           (Ptr{Void},Cint), ctx.ptr, a)
 
-get_antialias(ctx::CairoContext) = 
+get_antialias(ctx::CairoContext) =
     ccall((:cairo_get_antialias,_jl_libcairo), Cint,
           (Ptr{Void},), ctx.ptr)
 
@@ -744,12 +746,12 @@ function path_extents(ctx::CairoContext)
     dx2 = Cdouble[0]
     dy1 = Cdouble[0]
     dy2 = Cdouble[0]
-    
+
     ccall((:cairo_path_extents, _jl_libcairo),
-          Void, (Ptr{Void}, Ptr{Cdouble}, Ptr{Cdouble}, 
+          Void, (Ptr{Void}, Ptr{Cdouble}, Ptr{Cdouble},
           Ptr{Cdouble}, Ptr{Cdouble}),
           ctx.ptr, dx1, dy1, dx2, dy2)
-          
+
     return(dx1[1],dy1[1],dx2[1],dy2[1])
 end
 

--- a/src/compatibility.jl
+++ b/src/compatibility.jl
@@ -1,0 +1,10 @@
+# Warning-free compatibility with 0.3 and 0.4
+if VERSION < v"0.4.0-dev+980"
+    macro Dict(pairs...)
+        Expr(:dict, pairs...)
+    end
+else
+    macro Dict(pairs...)
+        Expr(:call, :Dict, pairs...)
+    end
+end

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -122,7 +122,7 @@ const OPERATOR_LIGHTEN = 18
 
 
 ## LaTex Token Dicts ##
-const _common_token_dict = [
+const _common_token_dict = @Dict(
     "\\{"              => "{",
     "\\}"              => "}",
     "\\_"              => "_",
@@ -131,18 +131,18 @@ const _common_token_dict = [
 
     ## ignore stray brackets
     "{"                => "",
-    "}"                => "",
-]
+    "}"                => ""
+)
 
-const _text_token_dict = [
+const _text_token_dict = @Dict(
     ## non-math symbols (p438)
     "\\S"              => "\ua7",
     "\\P"              => "\ub6",
     "\\dag"            => "\u2020",
-    "\\ddag"           => "\u2021",
-]
+    "\\ddag"           => "\u2021"
+)
 
-const _math_token_dict = [
+const _math_token_dict = @Dict(
 
     "-"                => "\u2212", # minus sign
 
@@ -392,8 +392,9 @@ const _math_token_dict = [
     "\\degrees"         => "\ub0",
     "\\arcdeg"          => "\ub0",
     "\\arcmin"          => "\u2032",
-    "\\arcsec"          => "\u2033",
-]
+    "\\arcsec"          => "\u2033"
+)
+
 const CAIRO_FILL_RULE_WINDING = int32(0);
 const CAIRO_FILL_RULE_EVEN_ODD = int32(1);
 


### PR DESCRIPTION
Couldn't see any reason to keep the AnyDicts untyped.
