### PR TITLE
Implement width and height for CairoContext

### DIFF
--- a/src/Cairo.jl
+++ b/src/Cairo.jl
@@ -353,6 +353,9 @@ function destroy(ctx::CairoContext)
     nothing
 end
 
+ width(ctx::CairoContext) =  width(ctx.surface)
+height(ctx::CairoContext) = height(ctx.surface)
+
 function copy(ctx::CairoContext)
     surf = surface_create_similar(ctx.surface)
     c = creategc(surf)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,16 @@
+using Cairo
+using Base.Test: @test, @test_throws
+
+surf = CairoImageSurface(100, 200, Cairo.FORMAT_ARGB32)
+@test width(surf) == 100
+@test height(surf) == 200
+ctx = CairoContext(surf)
+@test width(ctx) == 100
+@test height(ctx) == 200
+
 include("shape_functions.jl")
 include("test_stream.jl")
 include("tex.jl")
-
-using Base.Test: @test, @test_throws
-
 
 function test_pattern_get_surface()
     # test getting a surface from a surface pattern


### PR DESCRIPTION
Previously we had (with the new tests)
```jl
Cairo.CairoContext must implement width
 in width at no file
 in anonymous at test.jl:90
 in do_test at test.jl:50
 in include at ./boot.jl:259
 in include_from_node1 at ./loading.jl:267
 in process_options at ./client.jl:308
 in _start at ./client.jl:411
 in width at no file
 in anonymous at test.jl:90
 in do_test at test.jl:50
 in include at ./boot.jl:259
 in include_from_node1 at ./loading.jl:267
 in process_options at ./client.jl:308
 in _start at ./client.jl:411
while loading /home/tim/.julia/v0.3/Cairo/test/runtests.jl, in expression starting on line 8
```
so Cairo was not living up to the promises made by Graphics.
