### PR TITLE
To reduce deprecation warnings: some whitespace and Libc for strftime

### DIFF
--- a/samples/sample_arc.jl
+++ b/samples/sample_arc.jl
@@ -35,6 +35,6 @@ stroke(cr);
 
 ## mark picture with current date
 move_to(cr,0.0,12.0);
-set_source_rgb (cr, 0,0,0);
-show_text(cr,strftime(time()));
+set_source_rgb(cr, 0,0,0);
+show_text(cr,Libc.strftime(time()));
 write_to_png(c,"sample_arc.png");

--- a/samples/sample_arc_negative.jl
+++ b/samples/sample_arc_negative.jl
@@ -35,6 +35,6 @@ stroke(cr);
 
 ## mark picture with current date
 move_to(cr,0.0,12.0);
-set_source_rgb (cr, 0,0,0);
-show_text(cr,strftime(time()));
+set_source_rgb(cr, 0,0,0);
+show_text(cr,Libc.strftime(time()));
 write_to_png(c,"sample_arc_negative.png");

--- a/samples/sample_clip.jl
+++ b/samples/sample_clip.jl
@@ -29,6 +29,6 @@ stroke(cr);
 ## mark picture with current date
 restore(cr);
 move_to(cr,0.0,12.0);
-set_source_rgb (cr, 0,0,0);
-show_text(cr,strftime(time()));
+set_source_rgb(cr, 0,0,0);
+show_text(cr,Libc.strftime(time()));
 write_to_png(c,"sample_clip.png");

--- a/samples/sample_clip_image.jl
+++ b/samples/sample_clip_image.jl
@@ -13,24 +13,24 @@ save(cr);
 
 ## original example, following here
 
-arc (cr, 128.0, 128.0, 76.8, 0, 2*pi);
-clip (cr);
-new_path (cr); # path not consumed by clip
+arc(cr, 128.0, 128.0, 76.8, 0, 2*pi);
+clip(cr);
+new_path(cr); # path not consumed by clip
 
-image = read_from_png ("data/mulberry.png"); # should be create_from_png
+image = read_from_png("data/mulberry.png"); # should be create_from_png
 w = image.width;
 h = image.height;
 
 scale(cr, 256.0/w, 256.0/h);
 
-set_source_surface (cr, image, 0, 0);
-paint (cr);
+set_source_surface(cr, image, 0, 0);
+paint(cr);
 
 #cairo_surface_destroy not used here
 
 ## mark picture with current date
 restore(cr); 
 move_to(cr,0.0,12.0);
-set_source_rgb (cr, 0,0,0);
-show_text(cr,strftime(time()));
+set_source_rgb(cr, 0,0,0);
+show_text(cr,Libc.strftime(time()));
 write_to_png(c,"sample_clip_image.png");

--- a/samples/sample_copy_path.jl
+++ b/samples/sample_copy_path.jl
@@ -18,8 +18,8 @@ end
 function write_out_picture(filename::AbstractString,c::CairoSurface)
     ## mark picture with current date
     move_to(cr,0.0,12.0);
-    set_source_rgb (cr, 0,0,0);
-    show_text(cr,strftime(time()));
+    set_source_rgb(cr, 0,0,0);
+    show_text(cr,Libc.strftime(time()));
     ##
     write_to_png(c,filename);
     nothing
@@ -29,11 +29,11 @@ function example_copy_path(cr)
 
     save(cr);
     # single (large) character set with text_path+stroke
-    select_font_face (cr, "Sans", Cairo.FONT_SLANT_NORMAL,
+    select_font_face(cr, "Sans", Cairo.FONT_SLANT_NORMAL,
                         Cairo.FONT_WEIGHT_BOLD);
-    set_font_size (cr, 100.0);
+    set_font_size(cr, 100.0);
     translate(cr, 10.0, 100.0);
-    text_path (cr, "J");
+    text_path(cr, "J");
     stroke_preserve(cr);
 
     # copied and converted

--- a/samples/sample_curve_rectangle.jl
+++ b/samples/sample_curve_rectangle.jl
@@ -27,47 +27,47 @@ function shape_curve_rectangle(cr::CairoContext,x0::Real,y0::Real,
         end
     if (rect_width/2 < radius) 
         if (rect_height/2 < radius) 
-            move_to  (cr, x0, (y0 + y1)/2);
-            curve_to (cr, x0 ,y0, x0, y0, (x0 + x1)/2, y0);
-            curve_to (cr, x1, y0, x1, y0, x1, (y0 + y1)/2);
-            curve_to (cr, x1, y1, x1, y1, (x1 + x0)/2, y1);
-            curve_to (cr, x0, y1, x0, y1, x0, (y0 + y1)/2);
+            move_to(cr, x0, (y0 + y1)/2);
+            curve_to(cr, x0 ,y0, x0, y0, (x0 + x1)/2, y0);
+            curve_to(cr, x1, y0, x1, y0, x1, (y0 + y1)/2);
+            curve_to(cr, x1, y1, x1, y1, (x1 + x0)/2, y1);
+            curve_to(cr, x0, y1, x0, y1, x0, (y0 + y1)/2);
         else 
-            move_to  (cr, x0, y0 + radius);
-            curve_to (cr, x0 ,y0, x0, y0, (x0 + x1)/2, y0);
-            curve_to (cr, x1, y0, x1, y0, x1, y0 + radius);
-            line_to (cr, x1 , y1 - radius);
-            curve_to (cr, x1, y1, x1, y1, (x1 + x0)/2, y1);
-            curve_to (cr, x0, y1, x0, y1, x0, y1- radius);
+            move_to(cr, x0, y0 + radius);
+            curve_to(cr, x0 ,y0, x0, y0, (x0 + x1)/2, y0);
+            curve_to(cr, x1, y0, x1, y0, x1, y0 + radius);
+            line_to(cr, x1 , y1 - radius);
+            curve_to(cr, x1, y1, x1, y1, (x1 + x0)/2, y1);
+            curve_to(cr, x0, y1, x0, y1, x0, y1- radius);
         end
     
     else
         if (rect_height/2 < radius) 
-            move_to  (cr, x0, (y0 + y1)/2);
-            curve_to (cr, x0 , y0, x0 , y0, x0 + radius, y0);
-            line_to (cr, x1 - radius, y0);
-            curve_to (cr, x1, y0, x1, y0, x1, (y0 + y1)/2);
-            curve_to (cr, x1, y1, x1, y1, x1 - radius, y1);
-            line_to (cr, x0 + radius, y1);
-            curve_to (cr, x0, y1, x0, y1, x0, (y0 + y1)/2);
+            move_to(cr, x0, (y0 + y1)/2);
+            curve_to(cr, x0 , y0, x0 , y0, x0 + radius, y0);
+            line_to(cr, x1 - radius, y0);
+            curve_to(cr, x1, y0, x1, y0, x1, (y0 + y1)/2);
+            curve_to(cr, x1, y1, x1, y1, x1 - radius, y1);
+            line_to(cr, x0 + radius, y1);
+            curve_to(cr, x0, y1, x0, y1, x0, (y0 + y1)/2);
         else 
-            move_to  (cr, x0, y0 + radius);
-            curve_to (cr, x0 , y0, x0 , y0, x0 + radius, y0);
-            line_to (cr, x1 - radius, y0);
-            curve_to (cr, x1, y0, x1, y0, x1, y0 + radius);
-            line_to (cr, x1 , y1 - radius);
-            curve_to (cr, x1, y1, x1, y1, x1 - radius, y1);
-            line_to (cr, x0 + radius, y1);
-            curve_to (cr, x0, y1, x0, y1, x0, y1- radius);
+            move_to(cr, x0, y0 + radius);
+            curve_to(cr, x0 , y0, x0 , y0, x0 + radius, y0);
+            line_to(cr, x1 - radius, y0);
+            curve_to(cr, x1, y0, x1, y0, x1, y0 + radius);
+            line_to(cr, x1 , y1 - radius);
+            curve_to(cr, x1, y1, x1, y1, x1 - radius, y1);
+            line_to(cr, x0 + radius, y1);
+            curve_to(cr, x0, y1, x0, y1, x0, y1- radius);
         end
     end
-    close_path (cr);
+    close_path(cr);
 
-    set_source_rgb (cr, 0.5, 0.5, 1);
-    fill_preserve (cr);
-    set_source_rgba (cr, 0.5, 0, 0, 0.5);
-    set_line_width (cr, 10.0);
-    stroke (cr);
+    set_source_rgb(cr, 0.5, 0.5, 1);
+    fill_preserve(cr);
+    set_source_rgba(cr, 0.5, 0, 0, 0.5);
+    set_line_width(cr, 10.0);
+    stroke(cr);
     restore(cr);
     return;
     end
@@ -77,6 +77,6 @@ shape_curve_rectangle(cr,25.6,25.6,204.8,204.8,102.4);
 ## mark picture with current date
 restore(cr);
 move_to(cr,0.0,12.0);
-set_source_rgb (cr, 0,0,0);
-show_text(cr,strftime(time()));
+set_source_rgb(cr, 0,0,0);
+show_text(cr,Libc.strftime(time()));
 write_to_png(c,"sample_curve_rectangle.png");

--- a/samples/sample_curve_to.jl
+++ b/samples/sample_curve_to.jl
@@ -18,21 +18,21 @@ x1=102.4; y1=230.4;
 x2=153.6; y2=25.6;
 x3=230.4; y3=128.0;
 
-move_to (cr, x, y);
-curve_to (cr, x1, y1, x2, y2, x3, y3);
+move_to(cr, x, y);
+curve_to(cr, x1, y1, x2, y2, x3, y3);
 
-set_line_width (cr, 10.0);
-stroke (cr);
+set_line_width(cr, 10.0);
+stroke(cr);
 
-set_source_rgba (cr, 1, 0.2, 0.2, 0.6);
-set_line_width (cr, 6.0);
-move_to (cr,x,y);   line_to (cr,x1,y1);
-move_to (cr,x2,y2); line_to (cr,x3,y3);
-stroke (cr);
+set_source_rgba(cr, 1, 0.2, 0.2, 0.6);
+set_line_width(cr, 6.0);
+move_to(cr,x,y);   line_to(cr,x1,y1);
+move_to(cr,x2,y2); line_to(cr,x3,y3);
+stroke(cr);
 
 ## mark picture with current date
 restore(cr);
 move_to(cr,0.0,12.0);
-set_source_rgb (cr, 0,0,0);
-show_text(cr,strftime(time()));
+set_source_rgb(cr, 0,0,0);
+show_text(cr,Libc.strftime(time()));
 write_to_png(c,"sample_curve_to.png");

--- a/samples/sample_dash.jl
+++ b/samples/sample_dash.jl
@@ -20,20 +20,20 @@ dashes = [50.0,  # ink
 #ndash = length(dashes); not implemented as ndash on set_dash
 offset = -50.0;
 
-set_dash (cr, dashes, offset); 
-set_line_width (cr, 10.0);
+set_dash(cr, dashes, offset); 
+set_line_width(cr, 10.0);
 
-move_to (cr, 128.0, 25.6);
-line_to (cr, 230.4, 230.4);
-rel_line_to (cr, -102.4, 0.0);
-curve_to (cr, 51.2, 230.4, 51.2, 128.0, 128.0, 128.0);
+move_to(cr, 128.0, 25.6);
+line_to(cr, 230.4, 230.4);
+rel_line_to(cr, -102.4, 0.0);
+curve_to(cr, 51.2, 230.4, 51.2, 128.0, 128.0, 128.0);
 
-stroke (cr);
+stroke(cr);
 
 
 ## mark picture with current date
 restore(cr);
 move_to(cr,0.0,12.0);
-set_source_rgb (cr, 0,0,0);
-show_text(cr,strftime(time()));
+set_source_rgb(cr, 0,0,0);
+show_text(cr,Libc.strftime(time()));
 write_to_png(c,"sample_dash.png");

--- a/samples/sample_fill_and_stroke2.jl
+++ b/samples/sample_fill_and_stroke2.jl
@@ -11,27 +11,27 @@ restore(cr);
 
 save(cr);
 ## original example, following here
-move_to (cr, 128.0, 25.6);
-line_to (cr, 230.4, 230.4);
-rel_line_to (cr, -102.4, 0.0);
-curve_to (cr, 51.2, 230.4, 51.2, 128.0, 128.0, 128.0);
-close_path (cr);
+move_to(cr, 128.0, 25.6);
+line_to(cr, 230.4, 230.4);
+rel_line_to(cr, -102.4, 0.0);
+curve_to(cr, 51.2, 230.4, 51.2, 128.0, 128.0, 128.0);
+close_path(cr);
 
-move_to (cr, 64.0, 25.6);
-rel_line_to (cr, 51.2, 51.2);
-rel_line_to (cr, -51.2, 51.2);
-rel_line_to (cr, -51.2, -51.2);
-close_path (cr);
+move_to(cr, 64.0, 25.6);
+rel_line_to(cr, 51.2, 51.2);
+rel_line_to(cr, -51.2, 51.2);
+rel_line_to(cr, -51.2, -51.2);
+close_path(cr);
 
-set_line_width (cr, 10.0);
-set_source_rgb (cr, 0, 0, 1);
-fill_preserve (cr);
-set_source_rgb (cr, 0, 0, 0);
-stroke (cr);
+set_line_width(cr, 10.0);
+set_source_rgb(cr, 0, 0, 1);
+fill_preserve(cr);
+set_source_rgb(cr, 0, 0, 0);
+stroke(cr);
 
 ## mark picture with current date
 restore(cr);
 move_to(cr,0.0,12.0);
-set_source_rgb (cr, 0,0,0);
-show_text(cr,strftime(time()));
+set_source_rgb(cr, 0,0,0);
+show_text(cr,Libc.strftime(time()));
 write_to_png(c,"sample_fill_and_stroke2.png");

--- a/samples/sample_fill_style.jl
+++ b/samples/sample_fill_style.jl
@@ -11,28 +11,28 @@ restore(cr);
 
 save(cr);
 ## original example, following here
-set_line_width (cr, 6);
+set_line_width(cr, 6);
 
-rectangle (cr, 12, 12, 232, 70);
-new_sub_path (cr); arc (cr, 64, 64, 40, 0, 2*pi);
-new_sub_path (cr); arc_negative (cr, 192, 64, 40, 0, -2*pi);
+rectangle(cr, 12, 12, 232, 70);
+new_sub_path(cr); arc(cr, 64, 64, 40, 0, 2*pi);
+new_sub_path(cr); arc_negative(cr, 192, 64, 40, 0, -2*pi);
 
-set_fill_type (cr, Cairo.CAIRO_FILL_RULE_EVEN_ODD); # should be set_fill_rule
-set_source_rgb (cr, 0, 0.7, 0); fill_preserve (cr);
-set_source_rgb (cr, 0, 0, 0); stroke (cr);
+set_fill_type(cr, Cairo.CAIRO_FILL_RULE_EVEN_ODD); # should be set_fill_rule
+set_source_rgb(cr, 0, 0.7, 0); fill_preserve(cr);
+set_source_rgb(cr, 0, 0, 0); stroke(cr);
 
-translate (cr, 0, 128);
-rectangle (cr, 12, 12, 232, 70);
-new_sub_path (cr); arc (cr, 64, 64, 40, 0, 2*pi);
-new_sub_path (cr); arc_negative (cr, 192, 64, 40, 0, -2*pi);
+translate(cr, 0, 128);
+rectangle(cr, 12, 12, 232, 70);
+new_sub_path(cr); arc(cr, 64, 64, 40, 0, 2*pi);
+new_sub_path(cr); arc_negative(cr, 192, 64, 40, 0, -2*pi);
 
-set_fill_type (cr, Cairo.CAIRO_FILL_RULE_WINDING);
-set_source_rgb (cr, 0, 0, 0.9); fill_preserve (cr);
-set_source_rgb (cr, 0, 0, 0); stroke (cr);
+set_fill_type(cr, Cairo.CAIRO_FILL_RULE_WINDING);
+set_source_rgb(cr, 0, 0, 0.9); fill_preserve(cr);
+set_source_rgb(cr, 0, 0, 0); stroke(cr);
 
 ## mark picture with current date
 restore(cr);
 move_to(cr,0.0,12.0);
-set_source_rgb (cr, 0,0,0);
-show_text(cr,strftime(time()));
+set_source_rgb(cr, 0,0,0);
+show_text(cr,Libc.strftime(time()));
 write_to_png(c,"sample_fill_style.png");

--- a/samples/sample_gradient.jl
+++ b/samples/sample_gradient.jl
@@ -13,26 +13,26 @@ save(cr);
 
 ## original example, following here
 
-pat = pattern_create_linear (0.0, 0.0,  0.0, 256.0);
-pattern_add_color_stop_rgba (pat, 1, 0, 0, 0, 1);
-pattern_add_color_stop_rgba (pat, 0, 1, 1, 1, 1);
-rectangle (cr, 0, 0, 256, 256);
-set_source (cr, pat);
-fill (cr);
-destroy (pat);
+pat = pattern_create_linear(0.0, 0.0,  0.0, 256.0);
+pattern_add_color_stop_rgba(pat, 1, 0, 0, 0, 1);
+pattern_add_color_stop_rgba(pat, 0, 1, 1, 1, 1);
+rectangle(cr, 0, 0, 256, 256);
+set_source(cr, pat);
+fill(cr);
+destroy(pat);
 
-pat = pattern_create_radial (115.2, 102.4, 25.6,
-                             102.4,  102.4, 128.0);
-pattern_add_color_stop_rgba (pat, 0, 1, 1, 1, 1);
-pattern_add_color_stop_rgba (pat, 1, 0, 0, 0, 1);
-set_source (cr, pat);
-arc (cr, 128.0, 128.0, 76.8, 0, 2 * pi);
-fill (cr);
-destroy (pat);
+pat = pattern_create_radial(115.2, 102.4, 25.6,
+                            102.4,  102.4, 128.0);
+pattern_add_color_stop_rgba(pat, 0, 1, 1, 1, 1);
+pattern_add_color_stop_rgba(pat, 1, 0, 0, 0, 1);
+set_source(cr, pat);
+arc(cr, 128.0, 128.0, 76.8, 0, 2 * pi);
+fill(cr);
+destroy(pat);
 
 ## mark picture with current date
 restore(cr);
 move_to(cr,0.0,12.0);
-set_source_rgb (cr, 0,0,0);
-show_text(cr,strftime(time()));
+set_source_rgb(cr, 0,0,0);
+show_text(cr,Libc.strftime(time()));
 write_to_png(c,"sample_gradient.png");

--- a/samples/sample_image.jl
+++ b/samples/sample_image.jl
@@ -12,22 +12,22 @@ restore(cr);
 save(cr);
 ## original example, following here
 
-image = read_from_png ("data/mulberry.png");
+image = read_from_png("data/mulberry.png");
 w = image.width; 
 h = image.height;
 
-translate (cr, 128.0, 128.0);
-rotate (cr, 45* pi/180);
-scale  (cr, 256.0/w, 256.0/h);
-translate (cr, -0.5*w, -0.5*h);
+translate(cr, 128.0, 128.0);
+rotate(cr, 45* pi/180);
+scale(cr, 256.0/w, 256.0/h);
+translate(cr, -0.5*w, -0.5*h);
 
-set_source_surface (cr, image, 0, 0);
-paint (cr);
+set_source_surface(cr, image, 0, 0);
+paint(cr);
 #surface_destroy (image);
 
 ## mark picture with current date
 restore(cr);
 move_to(cr,0.0,12.0);
-set_source_rgb (cr, 0,0,0);
-show_text(cr,strftime(time()));
+set_source_rgb(cr, 0,0,0);
+show_text(cr,Libc.strftime(time()));
 write_to_png(c,"sample_image.png");

--- a/samples/sample_imagepattern.jl
+++ b/samples/sample_imagepattern.jl
@@ -11,30 +11,30 @@ restore(cr);
 
 save(cr);
 ## original example, following here
-image = read_from_png ("data/mulberry.png");
+image = read_from_png("data/mulberry.png");
 w = image.width; 
 h = image.height;
 
 pattern = CairoPattern(image);
 pattern_set_extend(pattern, Cairo.EXTEND_REPEAT);
 
-translate (cr, 128.0, 128.0);
-rotate (cr, pi / 4);
-scale (cr, 1 / sqrt (2), 1 / sqrt (2));
-translate (cr, -128.0, -128.0);
+translate(cr, 128.0, 128.0);
+rotate(cr, pi / 4);
+scale(cr, 1 / sqrt(2), 1 / sqrt(2));
+translate(cr, -128.0, -128.0);
 
 m = CairoMatrix(w/256.0 * 5.0,0,0,h/256.0 * 5.0,0,0);
 #matrix_init_scale (&matrix, w/256.0 * 5.0, h/256.0 * 5.0);
 
-set_matrix (pattern, m);
-set_source (cr, pattern);
+set_matrix(pattern, m);
+set_source(cr, pattern);
 
-rectangle (cr, 0, 0, 256.0, 256.0);
-fill (cr);
+rectangle(cr, 0, 0, 256.0, 256.0);
+fill(cr);
 
 ## mark picture with current date
 restore(cr);
 move_to(cr,0.0,12.0);
-set_source_rgb (cr, 0,0,0);
-show_text(cr,strftime(time()));
+set_source_rgb(cr, 0,0,0);
+show_text(cr,Libc.strftime(time()));
 write_to_png(c,"sample_imagepattern.png");

--- a/samples/sample_multi_segment_caps.jl
+++ b/samples/sample_multi_segment_caps.jl
@@ -12,22 +12,22 @@ restore(cr);
 save(cr);
 ## original example, following here
 
-move_to (cr, 50.0, 75.0);
-line_to (cr, 200.0, 75.0);
+move_to(cr, 50.0, 75.0);
+line_to(cr, 200.0, 75.0);
 
-move_to (cr, 50.0, 125.0);
-line_to (cr, 200.0, 125.0);
+move_to(cr, 50.0, 125.0);
+line_to(cr, 200.0, 125.0);
 
-move_to (cr, 50.0, 175.0);
-line_to (cr, 200.0, 175.0);
+move_to(cr, 50.0, 175.0);
+line_to(cr, 200.0, 175.0);
 
-set_line_width (cr, 30.0);
-set_line_cap (cr, Cairo.CAIRO_LINE_CAP_ROUND);
-stroke (cr);
+set_line_width(cr, 30.0);
+set_line_cap(cr, Cairo.CAIRO_LINE_CAP_ROUND);
+stroke(cr);
 
 ## mark picture with current date
 restore(cr);
 move_to(cr,0.0,12.0);
-set_source_rgb (cr, 0,0,0);
-show_text(cr,strftime(time()));
+set_source_rgb(cr, 0,0,0);
+show_text(cr,Libc.strftime(time()));
 write_to_png(c,"sample_multi_segment_caps.png");

--- a/samples/sample_rounded_rectangle.jl
+++ b/samples/sample_rounded_rectangle.jl
@@ -23,22 +23,22 @@ corner_radius = height / 10.0;   #* and corner curvature radius */
 radius = corner_radius / aspect;
 degrees = pi / 180.0;
 
-new_sub_path (cr);
-arc (cr, x + width - radius, y + radius, radius, -90 * degrees, 0 * degrees);
-arc (cr, x + width - radius, y + height - radius, radius, 0 * degrees, 90 * degrees);
-arc (cr, x + radius, y + height - radius, radius, 90 * degrees, 180 * degrees);
-arc (cr, x + radius, y + radius, radius, 180 * degrees, 270 * degrees);
-close_path (cr);
+new_sub_path(cr);
+arc(cr, x + width - radius, y + radius, radius, -90 * degrees, 0 * degrees);
+arc(cr, x + width - radius, y + height - radius, radius, 0 * degrees, 90 * degrees);
+arc(cr, x + radius, y + height - radius, radius, 90 * degrees, 180 * degrees);
+arc(cr, x + radius, y + radius, radius, 180 * degrees, 270 * degrees);
+close_path(cr);
 
-set_source_rgb (cr, 0.5, 0.5, 1);
-fill_preserve (cr);
-set_source_rgba (cr, 0.5, 0, 0, 0.5);
-set_line_width (cr, 10.0);
-stroke (cr);
+set_source_rgb(cr, 0.5, 0.5, 1);
+fill_preserve(cr);
+set_source_rgba(cr, 0.5, 0, 0, 0.5);
+set_line_width(cr, 10.0);
+stroke(cr);
 
 ## mark picture with current date
 restore(cr);
 move_to(cr,0.0,12.0);
-set_source_rgb (cr, 0,0,0);
-show_text(cr,strftime(time()));
+set_source_rgb(cr, 0,0,0);
+show_text(cr,Libc.strftime(time()));
 write_to_png(c,"sample_rounded_rectangle.png");

--- a/samples/sample_set_line_cap.jl
+++ b/samples/sample_set_line_cap.jl
@@ -11,28 +11,28 @@ restore(cr);
 
 save(cr);
 ## original example, following here
-set_line_width (cr, 30.0);
-set_line_cap  (cr, Cairo.CAIRO_LINE_CAP_BUTT); # default 
-move_to (cr, 64.0, 50.0); line_to (cr, 64.0, 200.0);
-stroke (cr);
-set_line_cap  (cr, Cairo.CAIRO_LINE_CAP_ROUND);
-move_to (cr, 128.0, 50.0); line_to (cr, 128.0, 200.0);
-stroke (cr);
-set_line_cap  (cr, Cairo.CAIRO_LINE_CAP_SQUARE);
-move_to (cr, 192.0, 50.0); line_to (cr, 192.0, 200.0);
-stroke (cr);
+set_line_width(cr, 30.0);
+set_line_cap(cr, Cairo.CAIRO_LINE_CAP_BUTT); # default 
+move_to(cr, 64.0, 50.0); line_to(cr, 64.0, 200.0);
+stroke(cr);
+set_line_cap(cr, Cairo.CAIRO_LINE_CAP_ROUND);
+move_to(cr, 128.0, 50.0); line_to(cr, 128.0, 200.0);
+stroke(cr);
+set_line_cap(cr, Cairo.CAIRO_LINE_CAP_SQUARE);
+move_to(cr, 192.0, 50.0); line_to(cr, 192.0, 200.0);
+stroke(cr);
 
 # draw helping lines 
-set_source_rgb (cr, 1, 0.2, 0.2);
-set_line_width (cr, 2.56);
-move_to (cr, 64.0, 50.0);  line_to (cr, 64.0, 200.0);
-move_to (cr, 128.0, 50.0); line_to (cr, 128.0, 200.0);
-move_to (cr, 192.0, 50.0); line_to (cr, 192.0, 200.0);
-stroke (cr);
+set_source_rgb(cr, 1, 0.2, 0.2);
+set_line_width(cr, 2.56);
+move_to(cr, 64.0, 50.0);  line_to(cr, 64.0, 200.0);
+move_to(cr, 128.0, 50.0); line_to(cr, 128.0, 200.0);
+move_to(cr, 192.0, 50.0); line_to(cr, 192.0, 200.0);
+stroke(cr);
 
 ## mark picture with current date
 restore(cr);
 move_to(cr,0.0,12.0);
-set_source_rgb (cr, 0,0,0);
-show_text(cr,strftime(time()));
+set_source_rgb(cr, 0,0,0);
+show_text(cr,Libc.strftime(time()));
 write_to_png(c,"sample_set_line_cap.png");

--- a/samples/sample_set_line_join.jl
+++ b/samples/sample_set_line_join.jl
@@ -11,28 +11,28 @@ restore(cr);
 
 save(cr);
 ## original example, following here
-set_line_width (cr, 40.96);
-move_to (cr, 76.8, 84.48);
-rel_line_to (cr, 51.2, -51.2);
-rel_line_to (cr, 51.2, 51.2);
-set_line_join (cr, Cairo.CAIRO_LINE_JOIN_MITER); # default 
-stroke (cr);
+set_line_width(cr, 40.96);
+move_to(cr, 76.8, 84.48);
+rel_line_to(cr, 51.2, -51.2);
+rel_line_to(cr, 51.2, 51.2);
+set_line_join(cr, Cairo.CAIRO_LINE_JOIN_MITER); # default 
+stroke(cr);
 
-move_to (cr, 76.8, 161.28);
-rel_line_to (cr, 51.2, -51.2);
-rel_line_to (cr, 51.2, 51.2);
-set_line_join (cr, Cairo.CAIRO_LINE_JOIN_BEVEL);
-stroke (cr);
+move_to(cr, 76.8, 161.28);
+rel_line_to(cr, 51.2, -51.2);
+rel_line_to(cr, 51.2, 51.2);
+set_line_join(cr, Cairo.CAIRO_LINE_JOIN_BEVEL);
+stroke(cr);
 
-move_to (cr, 76.8, 238.08);
-rel_line_to (cr, 51.2, -51.2);
-rel_line_to (cr, 51.2, 51.2);
-set_line_join (cr, Cairo.CAIRO_LINE_JOIN_ROUND);
-stroke (cr);
+move_to(cr, 76.8, 238.08);
+rel_line_to(cr, 51.2, -51.2);
+rel_line_to(cr, 51.2, 51.2);
+set_line_join(cr, Cairo.CAIRO_LINE_JOIN_ROUND);
+stroke(cr);
 
 ## mark picture with current date
 restore(cr);
 move_to(cr,0.0,12.0);
-set_source_rgb (cr, 0,0,0);
-show_text(cr,strftime(time()));
+set_source_rgb(cr, 0,0,0);
+show_text(cr,Libc.strftime(time()));
 write_to_png(c,"sample_set_line_join.png");

--- a/samples/sample_text.jl
+++ b/samples/sample_text.jl
@@ -12,32 +12,32 @@ restore(cr);
 save(cr);
 ## original example, following here
 
-select_font_face (cr, "Sans", Cairo.FONT_SLANT_NORMAL,
-                         Cairo.FONT_WEIGHT_BOLD);
-set_font_size (cr, 90.0);
+select_font_face(cr, "Sans", Cairo.FONT_SLANT_NORMAL,
+                 Cairo.FONT_WEIGHT_BOLD);
+set_font_size(cr, 90.0);
 
-move_to (cr, 10.0, 135.0);
-show_text (cr, "Hello");
+move_to(cr, 10.0, 135.0);
+show_text(cr, "Hello");
 
-move_to (cr, 70.0, 165.0);
-text_path (cr, "void");
-set_source_rgb (cr, 0.5, 0.5, 1);
-fill_preserve (cr);
-set_source_rgb (cr, 0, 0, 0);
-set_line_width (cr, 2.56);
-stroke (cr);
+move_to(cr, 70.0, 165.0);
+text_path(cr, "void");
+set_source_rgb(cr, 0.5, 0.5, 1);
+fill_preserve(cr);
+set_source_rgb(cr, 0, 0, 0);
+set_line_width(cr, 2.56);
+stroke(cr);
 
 # draw helping lines
-set_source_rgba (cr, 1, 0.2, 0.2, 0.6);
-arc (cr, 10.0, 135.0, 5.12, 0, 2*pi);
-close_path (cr);
-arc (cr, 70.0, 165.0, 5.12, 0, 2*pi);
-fill (cr);
+set_source_rgba(cr, 1, 0.2, 0.2, 0.6);
+arc(cr, 10.0, 135.0, 5.12, 0, 2*pi);
+close_path(cr);
+arc(cr, 70.0, 165.0, 5.12, 0, 2*pi);
+fill(cr);
 
 
 ## mark picture with current date
 restore(cr);
 move_to(cr,0.0,12.0);
-set_source_rgb (cr, 0,0,0);
-show_text(cr,strftime(time()));
+set_source_rgb(cr, 0,0,0);
+show_text(cr,Libc.strftime(time()));
 write_to_png(c,"sample_text.png");

--- a/samples/sample_text_align_center.jl
+++ b/samples/sample_text_align_center.jl
@@ -11,10 +11,10 @@ restore(cr);
 
 save(cr);
 ## original example, following here
-select_font_face (cr, "Sans", Cairo.FONT_SLANT_NORMAL,
-                         Cairo.FONT_WEIGHT_NORMAL);
-set_font_size (cr, 52.0);
-extents = text_extents (cr, "cairo");
+select_font_face(cr, "Sans", Cairo.FONT_SLANT_NORMAL,
+                 Cairo.FONT_WEIGHT_NORMAL);
+set_font_size(cr, 52.0);
+extents = text_extents(cr, "cairo");
 
 #
 # typedef struct {
@@ -29,23 +29,23 @@ extents = text_extents (cr, "cairo");
 x = 128.0-(extents[3]/2 + extents[1]);
 y = 128.0-(extents[4]/2 + extents[2]);
 
-move_to (cr, x, y);
-show_text (cr, "cairo");
+move_to(cr, x, y);
+show_text(cr, "cairo");
 
 # draw helping lines 
-set_source_rgba (cr, 1, 0.2, 0.2, 0.6);
-set_line_width (cr, 6.0);
-arc (cr, x, y, 10.0, 0, 2*pi);
-fill (cr);
-move_to (cr, 128.0, 0);
-rel_line_to (cr, 0, 256);
-move_to (cr, 0, 128.0);
-rel_line_to (cr, 256, 0);
-stroke (cr);
+set_source_rgba(cr, 1, 0.2, 0.2, 0.6);
+set_line_width(cr, 6.0);
+arc(cr, x, y, 10.0, 0, 2*pi);
+fill(cr);
+move_to(cr, 128.0, 0);
+rel_line_to(cr, 0, 256);
+move_to(cr, 0, 128.0);
+rel_line_to(cr, 256, 0);
+stroke(cr);
 
 ## mark picture with current date
 restore(cr);
 move_to(cr,0.0,12.0);
-set_source_rgb (cr, 0,0,0);
-show_text(cr,strftime(time()));
+set_source_rgb(cr, 0,0,0);
+show_text(cr,Libc.strftime(time()));
 write_to_png(c,"sample_text_align_center.png");

--- a/samples/sample_text_extents.jl
+++ b/samples/sample_text_extents.jl
@@ -11,10 +11,10 @@ restore(cr);
 
 save(cr);
 ## original example, following here
-select_font_face (cr, "Sans", Cairo.FONT_SLANT_NORMAL,
-                         Cairo.FONT_WEIGHT_NORMAL);
-set_font_size (cr, 100.0);
-extents = text_extents (cr, "cairo");
+select_font_face(cr, "Sans", Cairo.FONT_SLANT_NORMAL,
+                 Cairo.FONT_WEIGHT_NORMAL);
+set_font_size(cr, 100.0);
+extents = text_extents(cr, "cairo");
 
 #
 # typedef struct {
@@ -29,22 +29,22 @@ extents = text_extents (cr, "cairo");
 x = 25.0;
 y = 150.0;
 
-move_to (cr, x, y);
-show_text (cr, "cairo");
+move_to(cr, x, y);
+show_text(cr, "cairo");
 
 # draw helping lines 
-set_source_rgba (cr, 1, 0.2, 0.2, 0.6);
-set_line_width (cr, 6.0);
-arc (cr, x, y, 10.0, 0, 2*pi);
-fill (cr);
-move_to (cr, x,y);
-rel_line_to (cr, 0, -extents[4]);
-rel_line_to (cr, extents[3], 0);
-rel_line_to (cr, extents[1], -extents[2]);
-stroke (cr);
+set_source_rgba(cr, 1, 0.2, 0.2, 0.6);
+set_line_width(cr, 6.0);
+arc(cr, x, y, 10.0, 0, 2*pi);
+fill(cr);
+move_to(cr, x,y);
+rel_line_to(cr, 0, -extents[4]);
+rel_line_to(cr, extents[3], 0);
+rel_line_to(cr, extents[1], -extents[2]);
+stroke(cr);
 ## mark picture with current date
 restore(cr);
 move_to(cr,0.0,12.0);
-set_source_rgb (cr, 0,0,0);
-show_text(cr,strftime(time()));
+set_source_rgb(cr, 0,0,0);
+show_text(cr,Libc.strftime(time()));
 write_to_png(c,"sample_text_extents.png");


### PR DESCRIPTION
The title more or less says it, you got quite many deprecation warnings running the examples on a 0.4, as the programs copied literally from c-code and had some whitespace in the function call.