### PR TITLE
Add paint_with_alpha()

### DIFF
--- a/src/Cairo.jl
+++ b/src/Cairo.jl
@@ -438,11 +438,9 @@ function stroke_preserve(ctx::CairoContext)
     restore(ctx)
 end
 
-function paint_with_alpha(ctx::CairoContext, a = 0.5)
+function paint_with_alpha(ctx::CairoContext, a)
     ccall((:cairo_paint_with_alpha, _jl_libcairo),
-        Void,
-        (Ptr{Void}, Float64),
-        ctx.ptr, a)
+          Void, (Ptr{Void}, Float64), ctx.ptr, a)
 end
 
 function get_operator(ctx::CairoContext)

--- a/src/Cairo.jl
+++ b/src/Cairo.jl
@@ -55,7 +55,7 @@ export
     clip, clip_preserve, reset_clip,
 
     # fill, stroke, path, and shape commands
-    fill, fill_preserve, new_path, new_sub_path, close_path, paint, stroke,
+    fill, fill_preserve, new_path, new_sub_path, close_path, paint, paint_with_alpha, stroke,
     stroke_preserve, stroke_transformed, stroke_transformed_preserve,
     move_to, line_to, rel_line_to, rel_move_to,
     rectangle, circle, arc, arc_negative,
@@ -436,6 +436,13 @@ function stroke_preserve(ctx::CairoContext)
     reset_transform(ctx)
     ccall((:cairo_stroke_preserve, _jl_libcairo), Void, (Ptr{Void},), ctx.ptr)
     restore(ctx)
+end
+
+function paint_with_alpha(ctx::CairoContext, a = 0.5)
+    ccall((:cairo_paint_with_alpha, _jl_libcairo),
+        Void,
+        (Ptr{Void}, Float64),
+        ctx.ptr, a)
 end
 
 function get_operator(ctx::CairoContext)

--- a/test/shape_functions.jl
+++ b/test/shape_functions.jl
@@ -259,6 +259,38 @@ function rdots5(cr::CairoContext,
     end
 end
 
+# alpha transparency using paint_with_alpha
+function rdots6(cr::CairoContext,
+    rect_width::Real, rect_height::Real, radius::Real, n::Int)
+
+    clear_bg(cr,rect_width,rect_height)
+    px,py = randpos(n,rect_width,rect_height)
+
+    cc = radius + 3.0
+
+    s1 = Cairo.CairoARGBSurface(cc*2,cc*2)
+    c1 = Cairo.CairoContext(s1)
+    rectangle(c1,0,0,2*cc,2*cc)
+    set_source_rgba(c1,0,0,0,0)
+    paint_with_alpha(c1, 0.5)
+    new_path(c1)
+    arc(c1,radius+1,radius+1,radius,0,2*pi)
+    set_source_rgb(c1,0,0,1.0)
+    fill_preserve(c1)
+    set_source_rgb(c1,0,0,0)
+    set_line_width(c1,1.0)
+    stroke(c1)
+
+    p = Cairo.CairoPattern(s1)
+
+    for i=1:n
+        save(cr)
+        translate(cr,px[i]-cc,py[i]-cc)
+        set_source(cr,p)
+        paint_with_alpha(cr, 1 - i/n)
+        restore(cr)
+    end
+end
 
 # lines0, random x,y lines
 function lines0(cr::CairoContext, rect_width::Real, rect_height::Real, width::Real, n::Int)

--- a/test/test_speed.jl
+++ b/test/test_speed.jl
@@ -6,7 +6,7 @@ function test_all(;tmax = 2.0, save_flag = false)
     size_surface = [512];#,512,1024]; #three sizes of a surface
     paint_width = [0.5,1.0,3.0,5.0];
     shapes = [ddots1, ddots2, ddots3, ddots4, ddots5,
-              rdots1, rdots2, rdots3, rdots4, rdots5,
+              rdots1, rdots2, rdots3, rdots4, rdots5, rdots6,
               lines0, lines1, lines2, lines3, lines4];
     n_elements = [100,300,1000,3000,10000,30000,100000];
 


### PR DESCRIPTION
I'm trying to add paint_with_alpha to Cairo.jl. This addition appears to work. Not sure how to add tests, but this works:

    ## header to provide surface and context
    using Cairo
    c = CairoRGBSurface(256,256)
    cr = CairoContext(c)

    save(cr)
    set_source_rgb(cr, 0.8, 0.8, 0.8)    # light gray
    rectangle(cr, 0.0, 0.0, 256.0, 256.0) # background
    fill(cr)
    restore(cr)

    save(cr)
    image = read_from_png(Pkg.dir("Cairo", "samples/data/", "mulberry.png"))
    w = image.width
    h = image.height

    translate(cr, 128.0, 128.0)
    rotate(cr, 45* pi/180)
    scale(cr, 256.0/w, 256.0/h)
    translate(cr, -0.5*w, -0.5*h)

    set_source_surface(cr, image, 0, 0)
    paint(cr)
    restore(cr)

    save(cr)
    scale(cr, 256.0/w, 256.0/h)
    set_source_surface(cr, image, 0, 0)
    paint_with_alpha(cr)                         # defaults to 0.5
    restore(cr)

    ## mark picture with current date
    move_to(cr, 0.0, 12.0)
    set_source_rgb(cr, 0, 0, 0)
    show_text(cr, Libc.strftime(time()))
    write_to_png(c, "sample_image.png")

![sample_image](https://cloud.githubusercontent.com/assets/52289/12580207/8bdea2f4-c425-11e5-9518-d862cf640d9b.png)
