### PR TITLE
Allow to use FreeTypeAbstraction fonts and render glyph by index

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,7 @@ Cairo_jll = "1.16.0"
 Colors = "0.9, 0.10, 0.11, 0.12"
 Glib_jll = "2.59.0"
 Graphics = "0.4, 1"
+FreeTypeAbstraction = "0.10"
 Pango_jll = "1.42.4"
 julia = "1.3"
 

--- a/Project.toml
+++ b/Project.toml
@@ -5,18 +5,19 @@ version = "1.0.5"
 [deps]
 Cairo_jll = "83423d85-b0ee-5818-9007-b63ccbeb887a"
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
+FreeTypeAbstraction = "663a7486-cb36-511b-a19d-713bb74d65c9"
 Glib_jll = "7746bdde-850d-59dc-9ae8-88ece973131d"
 Graphics = "a2bd30eb-e257-5431-a919-1863eab51364"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Pango_jll = "36c8627f-9965-5494-a995-c6b170f724f3"
 
 [compat]
-julia = "1.3"
 Cairo_jll = "1.16.0"
 Colors = "0.9, 0.10, 0.11, 0.12"
 Glib_jll = "2.59.0"
 Graphics = "0.4, 1"
 Pango_jll = "1.42.4"
+julia = "1.3"
 
 [extras]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/Cairo.jl
+++ b/src/Cairo.jl
@@ -16,7 +16,7 @@ Base.@deprecate_binding _jl_libpango      Cairo.libpango   false
 Base.@deprecate_binding _jl_libpangocairo Cairo.libpango   false
 
 using Colors
-
+using FreeTypeAbstraction
 import Graphics
 using Graphics: BoundingBox, GraphicsContext, GraphicsDevice
 import Graphics: arc, clip, clip_preserve, close_path, creategc, device_to_user!, device_to_user_distance!, fill_preserve, height, line_to, move_to, new_path, new_sub_path, paint, rectangle, rel_line_to, rel_move_to, reset_clip, restore, rotate, save, scale, set_dash, set_line_width, set_source, set_source_rgb, set_source_rgba, stroke, stroke_preserve, stroke_transformed, stroke_transformed_preserve, textwidth, translate, user_to_device!, user_to_device_distance!, width, circle, reset_transform
@@ -1182,6 +1182,16 @@ function set_font_face(ctx::CairoContext, str::AbstractString)
           (Ptr{Nothing},), fontdesc)
 end
 
+function set_font_face(ctx::CairoContext, font::FreeTypeAbstraction.FTFont)
+    font_face = ccall(
+        (:cairo_ft_font_face_create_for_ft_face, libcairo),
+        Ptr{Nothing}, (FreeTypeAbstraction.FT_Face, Cint),
+        font, 0)
+    ccall((:cairo_set_font_face, libcairo), Nothing,
+          (Ptr{Nothing}, Ptr{Nothing}), ctx.ptr, font_face)
+    return font_face
+end
+
 function set_text(ctx::CairoContext, text::AbstractString, markup::Bool = false)
     if markup
         ccall((:pango_layout_set_markup,libpango), Nothing,
@@ -1251,6 +1261,25 @@ function text_path(ctx::CairoContext,value::AbstractString)
           ctx.ptr, String(value))
 end
 
+struct CairoGlyph
+    index::Culong
+    x::Cdouble
+    y::Cdouble
+end
+
+function show_glyph(ctx::CairoContext, glyph::CairoGlyph)
+    cg = Ref(glyph)
+    ccall((:cairo_show_glyphs, Cairo.libcairo),
+            Nothing, (Ptr{Nothing}, Ptr{CairoGlyph}, Cint),
+            ctx.ptr, cg, 1)
+end
+
+function glyph_path(ctx::CairoContext, glyph::CairoGlyph)
+    cg = Ref(glyph)
+    ccall((:cairo_glyph_path, Cairo.libcairo),
+            Nothing, (Ptr{Nothing}, Ptr{CairoGlyph}, Cint),
+            ctx.ptr, cg, 1)
+end
 
 function select_font_face(ctx::CairoContext,family::AbstractString,slant,weight)
     ccall((:cairo_select_font_face, libcairo),


### PR DESCRIPTION
These are small features that I am porting from CairoMakie so that they will be available to Luxor as well, to allow support for MathTeXEngine v0.5.

I do not know if I should add tests for those or what those tests should look like.