### PR TITLE
wrap `set_metadata` and `set_custom_metadata`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Pango_jll = "36c8627f-9965-5494-a995-c6b170f724f3"
 
 [compat]
-Cairo_jll = "1.16"
+Cairo_jll = "1.18"
 Colors = "0.12, 0.13"
 Glib_jll = "2.59.0"
 Graphics = "1"

--- a/src/Cairo.jl
+++ b/src/Cairo.jl
@@ -339,6 +339,16 @@ function CairoPDFSurface(filename::AbstractString, w_pts::Real, h_pts::Real)
     CairoSurface(ptr, w_pts, h_pts)
 end
 
+function set_metadata(surf, metadata_type, str)
+    ccall((:cairo_pdf_surface_set_metadata,libcairo), Cvoid,
+          (Ptr{Nothing}, Cint, Cstring), surf.ptr, metadata_type, str)
+end
+
+function set_custom_metadata(surf, name, value)
+    ccall((:cairo_pdf_surface_set_custom_metadata,libcairo), Cvoid,
+          (Ptr{Nothing}, Cstring, Cstring), surf.ptr, name, value)
+end
+
 ## EPS ##
 
 function CairoEPSSurface(stream::T, w::Real, h::Real) where {T<:IO}

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -64,7 +64,14 @@ const STATUS_DEVICE_TYPE_MISMATCH      = Int32(33)
 const STATUS_DEVICE_ERROR              = Int32(34)
 const STATUS_INVALID_MESH_CONSTRUCTION = Int32(35)
 const STATUS_DEVICE_FINISHED           = Int32(36)
-const STATUS_LAST_STATUS               = Int32(37)
+const STATUS_JBIG2_GLOBAL_MISSING      = Int32(37)
+const STATUS_PNG_ERROR                 = Int32(38)
+const STATUS_FREETYPE_ERROR            = Int32(39)
+const STATUS_WIN32_GDI_ERROR           = Int32(40)
+const STATUS_TAG_ERROR                 = Int32(41)
+const STATUS_DWRITE_ERROR              = Int32(42)
+const STATUS_SVG_FONT_ERROR            = Int32(43)
+const STATUS_LAST_STATUS               = Int32(44)
 
 const surface_t = Int32
 const CAIRO_SURFACE_TYPE_IMAGE            = Int32(0)
@@ -148,6 +155,13 @@ const OPERATOR_OVERLAY = 16
 const OPERATOR_DARKEN = 17
 const OPERATOR_LIGHTEN = 18
 
+const PDF_METADATA_TITLE = 0
+const PDF_METADATA_AUTHOR = 1
+const PDF_METADATA_SUBJECT = 2
+const PDF_METADATA_KEYWORDS = 3
+const PDF_METADATA_CREATOR = 4
+const PDF_METADATA_CREATE_DATE = 5
+const PDF_METADATA_MOD_DATE = 6
 
 ## LaTex Token Dicts ##
 const _common_token_dict = Dict(

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -69,9 +69,7 @@ const STATUS_PNG_ERROR                 = Int32(38)
 const STATUS_FREETYPE_ERROR            = Int32(39)
 const STATUS_WIN32_GDI_ERROR           = Int32(40)
 const STATUS_TAG_ERROR                 = Int32(41)
-const STATUS_DWRITE_ERROR              = Int32(42)
-const STATUS_SVG_FONT_ERROR            = Int32(43)
-const STATUS_LAST_STATUS               = Int32(44)
+const STATUS_LAST_STATUS               = Int32(42)
 
 const surface_t = Int32
 const CAIRO_SURFACE_TYPE_IMAGE            = Int32(0)

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -69,7 +69,9 @@ const STATUS_PNG_ERROR                 = Int32(38)
 const STATUS_FREETYPE_ERROR            = Int32(39)
 const STATUS_WIN32_GDI_ERROR           = Int32(40)
 const STATUS_TAG_ERROR                 = Int32(41)
-const STATUS_LAST_STATUS               = Int32(42)
+const STATUS_DWRITE_ERROR              = Int32(42)
+const STATUS_SVG_FONT_ERROR            = Int32(43)
+const STATUS_LAST_STATUS               = Int32(44)
 
 const surface_t = Int32
 const CAIRO_SURFACE_TYPE_IMAGE            = Int32(0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -166,6 +166,8 @@ end
     output_file_name = "a.pdf"
     surf = CairoPDFSurface(output_file_name,512,512)
     hdraw(surf,64,8,4)
+    Cairo.set_metadata(surf, Cairo.PDF_METADATA_CREATOR, "Cairo.jl")
+    Cairo.set_custom_metadata(surf, "id", "42")
     finish(surf)
 
     @test isfile(output_file_name)


### PR DESCRIPTION
Wrap these two methods for setting metadata in PDF surfaces. Also adds status enums that were added in cairo 1.16 and 1.18. Includes tests. Also bumps required Cairo version to 1.18.

Fixes https://github.com/JuliaGraphics/Cairo.jl/issues/360