### PR TITLE
Handle transitive dependencies with Julia master

### DIFF
--- a/src/Cairo.jl
+++ b/src/Cairo.jl
@@ -23,7 +23,7 @@ import Graphics: arc, clip, clip_preserve, close_path, creategc, device_to_user!
 import Base: copy, fill
 
 libcairo_version = VersionNumber(unsafe_string(
-      ccall((:cairo_version_string,Cairo_jll.libcairo),Cstring,()) ))
+      ccall((:cairo_version_string,libcairo),Cstring,()) ))
 libpango_version = VersionNumber(unsafe_string(
       ccall((:pango_version_string,Pango_jll.libpango),Cstring,()) ))
 if !Sys.iswindows()

--- a/src/Cairo.jl
+++ b/src/Cairo.jl
@@ -23,16 +23,16 @@ import Graphics: arc, clip, clip_preserve, close_path, creategc, device_to_user!
 import Base: copy, fill
 
 libcairo_version = VersionNumber(unsafe_string(
-      ccall((:cairo_version_string,Cairo.libcairo),Cstring,()) ))
+      ccall((:cairo_version_string,Cairo_jll.libcairo),Cstring,()) ))
 libpango_version = VersionNumber(unsafe_string(
-      ccall((:pango_version_string,Cairo.libpango),Cstring,()) ))
+      ccall((:pango_version_string,Pango_jll.libpango),Cstring,()) ))
 if !Sys.iswindows()
     libpangocairo_version = VersionNumber(unsafe_string(
-          ccall((:pango_version_string,Cairo.libpangocairo),Cstring,()) ))
+          ccall((:pango_version_string,Pango_jll.libpango),Cstring,()) ))
     libgobject_version = VersionNumber(
-          unsafe_load(cglobal((:glib_major_version, Cairo.libgobject), Cuint)),
-          unsafe_load(cglobal((:glib_minor_version, Cairo.libgobject), Cuint)),
-          unsafe_load(cglobal((:glib_micro_version, Cairo.libgobject), Cuint)))
+          unsafe_load(cglobal((:glib_major_version, Glib_jll.libglib), Cuint)),
+          unsafe_load(cglobal((:glib_minor_version, Glib_jll.libglib), Cuint)),
+          unsafe_load(cglobal((:glib_micro_version, Glib_jll.libglib), Cuint)))
 end
 
 import Base.show


### PR DESCRIPTION
The master branch of Julia has this recent change:
```
commit 9427f339c90d9c726deeaf05517c2ecabbf02bd6
Author: Sam Schweigel <sam.schweigel@juliahub.com>
Date:   Fri Sep 12 08:54:20 2025 -0700

    jl_dlfind: do not find symbols in library dependencies (#58815)
```

This means that a `ccall` to library `A` will not find symbols in `A`'s dependencies any more. For example, looking for `pango_version_string` in `Cairo_jll` does  not work any more. Instead, one has to look for this symbol in `Pango_jll`.

This PR updates Cairo in this respect. This change should be backward compatible, i.e. it should work with all earlier versions of Julia as well.